### PR TITLE
Fix `swagger-config-file` argument parsing

### DIFF
--- a/src/swagger-ui-action.ts
+++ b/src/swagger-ui-action.ts
@@ -107,7 +107,7 @@ export function validateConfig(): Config {
   const specFile = core.getInput('spec-file');
   const specUrl = core.getInput('spec-url');
   const swaggerConfigFile = core.getInput('swagger-config-file');
-  const swaggerConfigUrl = core.getInput('swagger-config-file');
+  const swaggerConfigUrl = core.getInput('swagger-config-url');
   const configMode = validateSwaggerUIConfig(
     specFile,
     specUrl,


### PR DESCRIPTION
Specifying a `swagger-config-file` always caused error on [line 159](https://github.com/Legion2/swagger-ui-action/blob/2a197da30e4459827b3d285f36e2af13c44bccc5/src/swagger-ui-action.ts#L159).

```error
Error: Only one configuration input can be used to configure swagger-ui with this action.You specified "swaggerConfigFile" and "swaggerConfigUrl" at the same time!
```